### PR TITLE
build: 🛠 Add artifact publishing to releases

### DIFF
--- a/.github/workflows/outputs.yml
+++ b/.github/workflows/outputs.yml
@@ -1,36 +1,28 @@
-name: generate outputs
+name: Generate Outputs for Review
+
+permissions:
+  contents: read
 
 on:
   merge_group:
   pull_request:
-  push:
-    branches:
-      - master
-# on:
-#   push:
-#     paths:
-#       - '**.kicad_sch'
-#       - '**.kicad_pcb'
-#   pull_request:
-#     paths:
-#       - '**.kicad_sch'
-#       - '**.kicad_pcb'
 
 jobs:
-  generate_outputs:
+  build:
+    name: Generate Outputs for Review
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: gitmarker
-      run: "for i in *.kicad_pcb; do git rev-parse --short HEAD | xargs -I % sed -i 's/{GITHASH}/%/g' $i; done" # add git marker
-    - uses: INTI-CMNB/KiBot@v2_k7
-      with:
-        # Required - kibot config file
-        config: config.kibot.yaml
-        # optional - prefix to output defined in config
-        dir: output
-    - name: upload results
-      uses: actions/upload-artifact@v3
-      with:
-        name: output
-        path: output
+      - uses: actions/checkout@v4
+      - name: gitmarker
+        run: "for i in *.kicad_pcb; do git rev-parse --short HEAD | xargs -I % sed -i 's/{GITHASH}/%/g' $i; done" # add git marker
+      - uses: INTI-CMNB/KiBot@v2_k7
+        with:
+          # Required - kibot config file
+          config: config.kibot.yaml
+          # optional - prefix to output defined in config
+          dir: output
+      - name: Upload temporary artifacts for review
+        uses: actions/upload-artifact@v4
+        with:
+          name: output
+          path: output

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,39 @@
+name: Upload Pre-Release Asset
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Upload Pre-Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set tag hash
+        id: tag
+        run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: gitmarker
+        run: "for i in *.kicad_pcb; do sed -i 's/{GITHASH}/${{ steps.tag.outputs.hash }}/g' $i; done" # add git marker
+      - uses: INTI-CMNB/KiBot@v2_k7
+        with:
+          # Required - kibot config file
+          config: config.kibot.yaml
+          # optional - prefix to output defined in config
+          dir: output
+      - name: Release with Notes
+        uses: softprops/action-gh-release@v2
+        with:
+          body: Publish new snapshot of PCB @ ${{ github.sha }}
+          tag_name: preview-${{ steps.tag.outputs.hash }}
+          prerelease: true
+          fail_on_unmatched_files: true
+          files: |
+            output/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Upload Release Asset
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set tag hash
+        id: tag
+        run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: gitmarker
+        run: "for i in *.kicad_pcb; do sed -i 's/{GITHASH}/${{ steps.tag.outputs.hash }}/g' $i; done" # add git marker
+      - uses: INTI-CMNB/KiBot@v2_k7
+        with:
+          # Required - kibot config file
+          config: config.kibot.yaml
+          # optional - prefix to output defined in config
+          dir: output
+      - name: Release with Notes
+        uses: softprops/action-gh-release@v2
+        with:
+          body: Publish new version of PCB
+          tag_name: ${{ github.ref_name }}
+          prerelease: false
+          make_latest: true
+          fail_on_unmatched_files: true
+          files: |
+            output/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a number of pipelines:
- the original pipeline is left only for PR reviews - it still generates artifact files, which expire
- a pre-release pipeline creates a pre-release from any commit to `master`
  - pre-releases are safe to ignore/delete, but files there will not expire
- a release pipeline will trigger for any release created with tag starting with "v", like "v1.0" or "v77.88.99"
  - it will create an official release and set it as latest, keeping artifact files

Closes #14 

---

For the pipeline being able to create a release, some changes in the repo settings need to be done:

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/c57ebb55-85d2-4e37-8430-53a79898501c">

The `permissions` tag in the pipeline configs will limit the scope of permissions to necessary level.

---

After this is merged, will need to fix whatever errors KiCad throws in the pipeline, then validate via pre-releases that appropriate set of files is collected, maybe repackage them a bit for more convenience - then once the file set is correct tag an official release.

Errors from the current KiCad pipeline, cc @Yatekii :
```
ERROR:Can't exit KiCad (pcbnew_do - interposer.py:654) (kibot - kiplot.py:130)
ERROR:Found 2 DRC errors and 9 unconnected pad/s or warnings (pcbnew_do - pcbnew_do:1443) (kibot - kiplot.py:130)
ERROR:(footprint_type_mismatch) Footprint component type doesn't match footprint pads (expected 'Through hole'; actual 'SMD'); Severity: error
    @(185.5000 mm, 86.0000 mm): Footprint J1 (pcbnew_do.kiauto.file_util - file_util.py:145) (kibot - kiplot.py:130)
ERROR:(footprint_type_mismatch) Footprint component type doesn't match footprint pads (expected 'Through hole'; actual 'SMD'); Severity: error
...
ERROR:DRC violations: 11 (kibot.gs - gs.py:850)
```