### PR TITLE
fix: 🐛 Zip up produced artifacts

### DIFF
--- a/.github/workflows/outputs.yml
+++ b/.github/workflows/outputs.yml
@@ -23,8 +23,12 @@ jobs:
           config: config.kibot.yaml
           # optional - prefix to output defined in config
           dir: output
+      - name: Prepare release
+        run: |
+          mkdir -p zipped/
+          zip -n zip -9 -o -D zipped/rusty-probe-pcb.zip output/*.csv output/*.html output/*.png output/*.pdf output/*.zip
       - name: Upload temporary artifacts for review
         uses: actions/upload-artifact@v4
         with:
-          name: output
-          path: output
+          name: rusty-probe-pcb
+          path: zipped/rusty-probe-pcb.zip

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,6 +28,10 @@ jobs:
           config: config.kibot.yaml
           # optional - prefix to output defined in config
           dir: output
+      - name: Prepare release
+        run: |
+          mkdir -p zipped/
+          zip -n zip -9 -o -D zipped/rusty-probe-pcb.zip output/*.csv output/*.html output/*.png output/*.pdf output/*.zip
       - name: Release with Notes
         uses: softprops/action-gh-release@v2
         with:
@@ -36,6 +40,6 @@ jobs:
           prerelease: true
           fail_on_unmatched_files: true
           files: |
-            output/**
+            zipped/rusty-probe-pcb.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ jobs:
           config: config.kibot.yaml
           # optional - prefix to output defined in config
           dir: output
+      - name: Prepare release
+        run: |
+          mkdir -p zipped/
+          zip -n zip -9 -o -D zipped/rusty-probe-pcb.zip output/*.csv output/*.html output/*.png output/*.pdf output/*.zip
       - name: Release with Notes
         uses: softprops/action-gh-release@v2
         with:
@@ -37,6 +41,6 @@ jobs:
           make_latest: true
           fail_on_unmatched_files: true
           files: |
-            output/**
+            zipped/rusty-probe-pcb.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Put everything into a zip file
- Keep gerbers and drills in their own zip file within the outer zip package

- Produce the same structure zip file in all pipelines, so you can review what goes into it starting from the PR builds.